### PR TITLE
Some modernization of the plugin

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,28 @@
+googleanalytics Plugin for DokuWiki
+
+Plugin to embed your Google Analytics code for your site, which
+allows you to track your visitors.
+
+All documentation for this plugin can be found at
+https://www.dokuwiki.org/plugin:googleanalytics
+
+If you install this plugin manually, make sure it is installed in
+lib/plugins/googleanalytics/ - if the folder is called different it
+will not work!
+
+Please refer to http://www.dokuwiki.org/plugins for additional info
+on how to install plugins in DokuWiki.
+
+----
+Copyright (C) Terence J. Grant <tjgrant@tatewake.com> et al.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+See the COPYING file in your DokuWiki folder for details

--- a/action.php
+++ b/action.php
@@ -28,15 +28,13 @@ class action_plugin_googleanalytics extends DokuWiki_Action_Plugin {
         global $JSINFO;
         global $INFO;
         global $ACT;
-        global $QUERY;
-        global $ID;
-        global $INPUT;
 
         if(!$this->gaEnabled) return;
         $trackingId = $this->getConf('GAID');
         if(!$trackingId) return;
         if($this->getConf('dont_count_admin') && $INFO['isadmin']) return;
         if($this->getConf('dont_count_users') && $_SERVER['REMOTE_USER']) return;
+        act_clean($ACT);
 
         $options = array();
         if($this->getConf('track_users') && $_SERVER['REMOTE_USER']) {
@@ -47,25 +45,52 @@ class action_plugin_googleanalytics extends DokuWiki_Action_Plugin {
             $options['legacyCookieDomain'] = $this->getConf('domainName');
         }
 
-        // normalize the pageview
+        $JSINFO['ga'] = array(
+            'trackingId' => $trackingId,
+            'anonymizeIp' => (bool) $this->getConf('anonymize'),
+            'action' => $ACT,
+            'trackOutboundLinks' => (bool) $this->getConf('track_links'),
+            'options' => $options,
+            'pageview' => $this->getPageView(),
+        );
+    }
+
+    /**
+     * normalize the pageview
+     *
+     * @return string
+     */
+    protected function getPageView() {
+        global $QUERY;
+        global $ID;
+        global $INPUT;
+        global $ACT;
+
+        // clean up parameters to log
+        $params = $_GET;
+        if(isset($params['do'])) unset($params['do']);
+        if(isset($params['id'])) unset($params['id']);
+
+        // decide on virtual views
         if($ACT == 'search') {
-            $view = '~search/?' . rawurlencode($QUERY);
+            $view = '~search/';
+            $params['q'] = $QUERY;
         } elseif($ACT == 'admin') {
             $page = $INPUT->str('page');
             $view = '~admin';
             if($page) $view .= '/' . $page;
+            if(isset($params['page'])) unset($params['page']);
         } else {
             $view = str_replace(':', '/', $ID); // slashes needed for Content Drilldown
         }
-        $view = DOKU_REL . $view; // prepend basedir, allows logging multiple dir based animals in one tracker
 
-        $JSINFO['ga'] = array(
-            'trackingId' => $trackingId,
-            'anonymizeIp' => (bool) $this->getConf('anonymize'),
-            'action' => act_clean($ACT),
-            'trackOutboundLinks' => (bool) $this->getConf('track_links'),
-            'options' => $options,
-            'pageview' => $view
-        );
+        // prepend basedir, allows logging multiple dir based animals in one tracker
+        $view = DOKU_REL . $view;
+
+        // append query parameters
+        $query = http_build_query($params, '', '&');
+        if($query) $view .= '?' . $query;
+
+        return $view;
     }
 }

--- a/action.php
+++ b/action.php
@@ -7,7 +7,7 @@ if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC . 'lib/plugins/');
  */
 class action_plugin_googleanalytics extends DokuWiki_Action_Plugin {
 
-    private $mustNotShow = false;
+    private $gaEnabled = true;
 
     /**
      * Register its handlers with the DokuWiki's event controller
@@ -15,78 +15,41 @@ class action_plugin_googleanalytics extends DokuWiki_Action_Plugin {
      * @param Doku_Event_Handler $controller
      */
     function register(Doku_Event_Handler $controller) {
-        $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, '_addHeaders');
-        $controller->register_hook('POPUPVIEWER_DOKUWIKI_STARTED', 'BEFORE', $this, 'popupviewer_handler');
-        $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'ajax_provider');
+        $controller->register_hook('DOKUWIKI_STARTED', 'AFTER', $this, 'gaConfig');
     }
 
     /**
-     * Default setup of the needed javascript for tracking
+     * Initialize the Google Analytics config
      *
      * @param Doku_Event $event
      * @param array $param
      */
-    function _addHeaders(Doku_Event $event, $param) {
+    public function gaConfig(Doku_Event $event, $param) {
+        global $JSINFO;
         global $INFO;
-        if($this->mustNotShow || !$this->getConf('GAID')) return;
+        global $ACT;
+
+        if(!$this->gaEnabled) return;
+        $trackingId = $this->getConf('GAID');
+        if(!$trackingId) return;
         if($this->getConf('dont_count_admin') && $INFO['isadmin']) return;
         if($this->getConf('dont_count_users') && $_SERVER['REMOTE_USER']) return;
 
         $options = array();
-        $options[] = "_gaq.push(['_setAccount', '" . $this->getConf('GAID') . "'])";
-
-        if($this->getConf('anonymize')) {
-            $options[] = "_gaq.push(['_gat._anonymizeIp'])";
+        if($this->getConf('track_users') && $_SERVER['REMOTE_USER']) {
+            $options['userId'] = md5(auth_cookiesalt() . 'googleanalytics' . $_SERVER['REMOTE_USER']);
+        }
+        if($this->getConf('domainName')) {
+            $options['cookieDomain'] = $this->getConf('domainName');
+            $options['legacyCookieDomain'] = $this->getConf('domainName');
         }
 
-        $domainName = $this->getConf('domainName');
-        if(!empty($domainName)) {
-            $options[] = "_gaq.push(['_setDomainName', '" . $domainName . "'])";
-        }
-
-        $options[] = "_gaq.push(['_gat._forceSSL'])";
-        $options[] = "_gaq.push(['_trackPageview']);";
-
-        $event->data["script"][] = array(
-            "type" => "text/javascript",
-            "_data" => "var _gaq = _gaq || [];" . implode(';', $options)
-        );
-
-        $event->data["script"][] = array(
-            "type" => "text/javascript",
-            "_data" => "(function() {var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true; ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js'; var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s); })();"
+        $JSINFO['ga'] = array(
+            'trackingId' => $trackingId,
+            'anonymizeIp' => (bool) $this->getConf('anonymize'),
+            'action' => act_clean($ACT),
+            'trackOutboundLinks' => (bool) $this->getConf('track_links'),
+            'options' => $options,
         );
     }
-
-    /**
-     * Track links in the popuviewer plugin
-     *
-     * @link https://www.dokuwiki.org/plugin:popupviewer
-     * @param Doku_Event $event
-     * @param array $param
-     */
-    function popupviewer_handler(Doku_Event $event, $param) {
-        global $ID;
-
-        // Only track self
-        $event->data["popupscript"][] = array(
-            "type" => "text/popupscript",
-            "_data" => "googleanalytics_trackLink(typeof trackLink == 'string'?trackLink:'" . wl($ID) . "');"
-        );
-
-        $this->mustNotShow = true;
-    }
-
-    /**
-     * Handle page tracking when pages are loaded via AJAX
-     *
-     * @link https://www.dokuwiki.org/plugin:fastwiki
-     * @param Doku_Event $event
-     * @param array $param
-     */
-    function ajax_provider(Doku_Event $event, $param) {
-        global $ACT;
-        $this->mustNotShow = $ACT != 'show';
-    }
-
 }

--- a/action.php
+++ b/action.php
@@ -1,69 +1,92 @@
 <?php
 if(!defined('DOKU_INC')) die();
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once(DOKU_PLUGIN.'action.php');
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC . 'lib/plugins/');
 
+/**
+ * Class action_plugin_googleanalytics
+ */
 class action_plugin_googleanalytics extends DokuWiki_Action_Plugin {
 
-	private $mustNotShow = false;
+    private $mustNotShow = false;
 
-	/**
-	 * Register its handlers with the DokuWiki's event controller
-	 */
-	function register(Doku_Event_Handler $controller) {
-            $controller->register_hook('POPUPVIEWER_DOKUWIKI_STARTED', 'BEFORE', $this, 'popupviewer_handler');
-	    $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE',  $this, '_addHeaders');
-            $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'ajax_provider');
-	}
+    /**
+     * Register its handlers with the DokuWiki's event controller
+     *
+     * @param Doku_Event_Handler $controller
+     */
+    function register(Doku_Event_Handler $controller) {
+        $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, '_addHeaders');
+        $controller->register_hook('POPUPVIEWER_DOKUWIKI_STARTED', 'BEFORE', $this, 'popupviewer_handler');
+        $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'ajax_provider');
+    }
 
-	function popupviewer_handler(&$event) {
+    /**
+     * Default setup of the needed javascript for tracking
+     *
+     * @param Doku_Event $event
+     * @param array $param
+     */
+    function _addHeaders(Doku_Event $event, $param) {
+        global $INFO;
+        if($this->mustNotShow || !$this->getConf('GAID')) return;
+        if($this->getConf('dont_count_admin') && $INFO['isadmin']) return;
+        if($this->getConf('dont_count_users') && $_SERVER['REMOTE_USER']) return;
 
-	    global $ID;
+        $options = array();
+        $options[] = "_gaq.push(['_setAccount', '" . $this->getConf('GAID') . "'])";
 
-	    // Only track self
-            $event->data["popupscript"][] = array (
-                "type" => "text/popupscript",
-                "_data" => "googleanalytics_trackLink(typeof trackLink == 'string'?trackLink:'".wl($ID)."');"
-            );
+        if($this->getConf('anonymize')) {
+            $options[] = "_gaq.push(['_gat._anonymizeIp'])";
+        }
 
-    	    $this->mustNotShow = true;
-	}
+        $domainName = $this->getConf('domainName');
+        if(!empty($domainName)) {
+            $options[] = "_gaq.push(['_setDomainName', '" . $domainName . "'])";
+        }
 
-	function ajax_provider(&$event) {
+        $options[] = "_gaq.push(['_gat._forceSSL'])";
+        $options[] = "_gaq.push(['_trackPageview']);";
 
-            global $ACT;
-            $this->mustNotShow = $ACT != 'show';
-	}
+        $event->data["script"][] = array(
+            "type" => "text/javascript",
+            "_data" => "var _gaq = _gaq || [];" . implode(';', $options)
+        );
 
-	function _addHeaders (&$event, $param) {
-            global $INFO;
-            if($this->mustNotShow || !$this->getConf('GAID')) return;
-            if($this->getConf('dont_count_admin') && $INFO['isadmin']) return;
-            if($this->getConf('dont_count_users') && $_SERVER['REMOTE_USER']) return;
+        $event->data["script"][] = array(
+            "type" => "text/javascript",
+            "_data" => "(function() {var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true; ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js'; var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s); })();"
+        );
+    }
 
-            $options = array();
-            $options[] = "_gaq.push(['_setAccount', '".$this->getConf('GAID')."'])";
+    /**
+     * Track links in the popuviewer plugin
+     *
+     * @link https://www.dokuwiki.org/plugin:popupviewer
+     * @param Doku_Event $event
+     * @param array $param
+     */
+    function popupviewer_handler(Doku_Event $event, $param) {
+        global $ID;
 
-            if ( $this->getConf('anonymize') ) {
-                $options[] = "_gaq.push(['_gat._anonymizeIp'])";
-            }
+        // Only track self
+        $event->data["popupscript"][] = array(
+            "type" => "text/popupscript",
+            "_data" => "googleanalytics_trackLink(typeof trackLink == 'string'?trackLink:'" . wl($ID) . "');"
+        );
 
-            $domainName = $this->getConf('domainName');
-            if ( !empty($domainName) ) {
-                $options[] = "_gaq.push(['_setDomainName', '".$domainName."'])";
-            }
+        $this->mustNotShow = true;
+    }
 
-            $options[] = "_gaq.push(['_gat._forceSSL'])";
-            $options[] = "_gaq.push(['_trackPageview']);";
+    /**
+     * Handle page tracking when pages are loaded via AJAX
+     *
+     * @link https://www.dokuwiki.org/plugin:fastwiki
+     * @param Doku_Event $event
+     * @param array $param
+     */
+    function ajax_provider(Doku_Event $event, $param) {
+        global $ACT;
+        $this->mustNotShow = $ACT != 'show';
+    }
 
-            $event->data["script"][] = array (
-                "type" => "text/javascript",
-                "_data" => "var _gaq = _gaq || [];" . implode(';', $options)
-            );
-
-            $event->data["script"][] = array (
-                "type" => "text/javascript",
-                "_data" => "(function() {var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true; ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js'; var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s); })();"
-            );
-	}
 }

--- a/action.php
+++ b/action.php
@@ -28,6 +28,9 @@ class action_plugin_googleanalytics extends DokuWiki_Action_Plugin {
         global $JSINFO;
         global $INFO;
         global $ACT;
+        global $QUERY;
+        global $ID;
+        global $INPUT;
 
         if(!$this->gaEnabled) return;
         $trackingId = $this->getConf('GAID');
@@ -44,12 +47,25 @@ class action_plugin_googleanalytics extends DokuWiki_Action_Plugin {
             $options['legacyCookieDomain'] = $this->getConf('domainName');
         }
 
+        // normalize the pageview
+        if($ACT == 'search') {
+            $view = '~search/?' . rawurlencode($QUERY);
+        } elseif($ACT == 'admin') {
+            $page = $INPUT->str('page');
+            $view = '~admin';
+            if($page) $view .= '/' . $page;
+        } else {
+            $view = str_replace(':', '/', $ID); // slashes needed for Content Drilldown
+        }
+        $view = DOKU_REL . $view; // prepend basedir, allows logging multiple dir based animals in one tracker
+
         $JSINFO['ga'] = array(
             'trackingId' => $trackingId,
             'anonymizeIp' => (bool) $this->getConf('anonymize'),
             'action' => act_clean($ACT),
             'trackOutboundLinks' => (bool) $this->getConf('track_links'),
             'options' => $options,
+            'pageview' => $view
         );
     }
 }

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,3 +1,9 @@
 <?php
 
+$conf['GAID'] = '';
+$conf['dont_count_admin'] = 0;
+$conf['dont_count_users'] = 0;
 $conf['anonymize'] = 1;
+$conf['track_users'] = 0;
+$conf['track_links'] = 0;
+$conf['domainName'] = '';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,7 +1,9 @@
 <?php
+
 $meta['GAID'] = array('string');
 $meta['dont_count_admin'] = array('onoff');
 $meta['dont_count_users'] = array('onoff');
-
 $meta['anonymize'] = array('onoff');
+$meta['track_users'] = array('onoff');
+$meta['track_links'] = array('onoff');
 $meta['domainName'] = array('string');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,4 +1,9 @@
 <?php
-$lang['GAID'] = 'Google Analitycs ID';
+$lang['GAID'] = 'Your Google Analytics ID (UA-XXXXX)';
 $lang['dont_count_admin'] = 'Don\'t count admin/superuser';
 $lang['dont_count_users'] = 'Don\'t count logged in users';
+$lang['anonymize'] = 'Send anonymized IP addresses to google.';
+$lang['track_users'] = 'Track logged in users. Needs <a href="https://support.google.com/analytics/answer/3123662?hl=en">user tracking</a> enabled. Users will not be identifable in Google Analytics.';
+$lang['track_links'] = 'Track outgoing links.';
+$lang['domainName'] = 'Configure the cookie domain - useful if the tracker is shared over multiple sub domains. Leave empty for automatic detection';
+

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,9 +1,9 @@
 <?php
-$lang['GAID'] = 'Your Google Analytics ID (UA-XXXXX)';
+$lang['GAID'] = 'Your Google Analytics ID (UA-XXXXXX-XX)';
 $lang['dont_count_admin'] = 'Don\'t count admin/superuser';
 $lang['dont_count_users'] = 'Don\'t count logged in users';
-$lang['anonymize'] = 'Send anonymized IP addresses to google.';
-$lang['track_users'] = 'Track logged in users. Needs <a href="https://support.google.com/analytics/answer/3123662?hl=en">user tracking</a> enabled. Users will not be identifable in Google Analytics.';
+$lang['anonymize'] = 'Send anonymized IP addresses to Google.';
+$lang['track_users'] = 'Track logged in users across different devices. Needs <a href="https://support.google.com/analytics/answer/3123662?hl=en">user tracking</a> enabled. Users will not be identifable in Google Analytics!';
 $lang['track_links'] = 'Track outgoing links.';
-$lang['domainName'] = 'Configure the cookie domain - useful if the tracker is shared over multiple sub domains. Leave empty for automatic detection';
+$lang['domainName'] = 'Configure the cookie domain. Should usually be left empty';
 

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base    googleanalytics
 author  Terence J. Grant
 email   tjgrant@tatewake.com
-date    2016-02-02
+date    2017-02-07
 name    Google Analytics Plugin
 desc    Plugin to embed your Google Analytics code for your site, which allows you to track your visitors.
-url     http://www.dokuwiki.org/plugin:googleanalytics
+url     https://www.dokuwiki.org/plugin:googleanalytics

--- a/script.js
+++ b/script.js
@@ -26,6 +26,8 @@ if (JSINFO.ga) {
     ga('set', 'anonymizeIp', JSINFO.ga.anonymizeIp);
 
     // track pageview and action
+    ga('set', 'dimension1', JSINFO.ga.action);
+    ga('set', 'dimension2', JSINFO.ga.id);
     ga('send', 'pageview', JSINFO.ga.pageview);
     ga('send', 'event', 'wiki-action', JSINFO.ga.action, JSINFO.id, {
         nonInteraction: true // this is an automatic event with the page load

--- a/script.js
+++ b/script.js
@@ -26,7 +26,7 @@ if (JSINFO.ga) {
     ga('set', 'anonymizeIp', JSINFO.ga.anonymizeIp);
 
     // track pageview and action
-    ga('send', 'pageview');
+    ga('send', 'pageview', JSINFO.ga.pageview);
     ga('send', 'event', 'wiki-action', JSINFO.ga.action, JSINFO.id, {
         nonInteraction: true // this is an automatic event with the page load
     });

--- a/script.js
+++ b/script.js
@@ -1,43 +1,50 @@
 /**
- * 
- * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @author     Gerry Weißbach <gweissbach@inetsoftware.de>
+ * Set up Google analytics
+ *
+ * All configuration is done in the JSINFO.ga object initialized in
+ * action.php
  */
+if (JSINFO.ga) {
+    /* default google tracking initialization */
+    (function (i, s, o, g, r, a, m) {
+        i['GoogleAnalyticsObject'] = r;
+        //noinspection CommaExpressionJS
+        i[r] = i[r] || function () {
+                (i[r].q = i[r].q || []).push(arguments)
+            }, i[r].l = 1 * new Date();
+        //noinspection CommaExpressionJS
+        a = s.createElement(o),
+            m = s.getElementsByTagName(o)[0];
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
-var googleanalytics_trackLink = function(link, prefix) {
+    // initalize and set options
+    ga('create', JSINFO.ga.trackingId, 'auto', JSINFO.ga.options);
+    ga('set', 'forceSSL', true);
+    ga('set', 'anonymizeIp', JSINFO.ga.anonymizeIp);
 
-	if ( typeof _gaq != 'undefined' )
-	{
-    	_gaq.push(['_trackPageview', (typeof prefix != 'undefined' ? prefix : '') + link]);
-	}
-};
+    // track pageview and action
+    ga('send', 'pageview');
+    ga('send', 'event', 'wiki-action', JSINFO.ga.action, JSINFO.id, {
+        nonInteraction: true // this is an automatic event with the page load
+    });
 
-var googleanalytics_trackEvent = function(category, action, label) {
-
-	if ( typeof _gaq != 'undefined' )
-	{
-    	_gaq.push(['_trackEvent', category, action, label]);
-	}
-};
-
-var googleanalytics_registerTracking = function() {
-    
-		if ( typeof _gaq == 'undefined' ) { return; }
-    	_gaq.push(['_setAllowLinker', true]);
-		
-		var expression = new RegExp("^([^\?]*)\?[^=]*$");
-		jQuery('a.media:not([tracking]), a.mediafile:not([tracking]), a.interwiki:not([tracking]), a.urlextern:not([tracking])').each(function(){
-			
-			
-			jQuery(this).click(function(e){
-				
-				googleanalytics_trackLink(this.href.replace(expression, "$1"), '/outgoing?url='); // but track full URL to be sure
-				return true;
-			}).attr('tracking');
-		});
-
-};
-
-(function($){
-	$(googleanalytics_registerTracking);
-})(jQuery);
+    // track outgoing links, once the document was loaded
+    if (JSINFO.ga.trackOutboundLinks) {
+        jQuery(function () {
+            // https://support.google.com/analytics/answer/1136920?hl=en
+            jQuery('a.urlextern, a.interwiki').click(function (e) {
+                e.preventDefault();
+                var url = this.href;
+                ga('send', 'event', 'outbound', 'click', url, {
+                    'transport': 'beacon',
+                    'hitCallback': function () {
+                        document.location = url;
+                    }
+                });
+            });
+        });
+    }
+}


### PR DESCRIPTION
This refactors the plugin and extends it to improve its usefulness:

* it makes use of the new universal tracking code (recommended by google)
* all configuration is done through our JSINFO object while the setup becomes part of our regular JS dispatching (no additional requests except for Google's tracking script itself)
* makes use of the new ga() methods of google analytics
* triggers events for the current action (show, edit, etc.)
* logs action and id as custom dimensions
* outgoing links are now tracked through the event system as recommended by google
* logged in users can optionally tracked across multiple devices (using an anonymous ID)
* pageviews are normalized and virtual pageviews for search and admin are introduced
* the virtual pageview for search makes it easy to set up tracking of the internal site search

There were two diverging versions of the plugin by you and @gamma - I merged both trees before applying my changes. However I removed the code for supporting popup viewer and fastwiki(?) because I don't know these plugins well enough. I believe readding support should be trivial for someone who actually uses them.

The ultimate goal of my changes is to improve the plugin further in the future and provide added value on top of just having easy way of integrating the tracking. The plugin should automatically track interesting wiki related events and metrics.

Since the plugin makes google's ga() method globally available, other plugins could easily integrate additional event logs.

Once this is merged I can update the documentation and more info on how to configure Google Analytics to make most out of the new data available through this plugin.