### PR TITLE
Check ga existence before tracking links

### DIFF
--- a/script.js
+++ b/script.js
@@ -38,14 +38,15 @@ if (JSINFO.ga) {
         jQuery(function () {
             // https://support.google.com/analytics/answer/1136920?hl=en
             jQuery('a.urlextern, a.interwiki').click(function (e) {
-                e.preventDefault();
                 var url = this.href;
-                ga('send', 'event', 'outbound', 'click', url, {
-                    'transport': 'beacon',
-                    'hitCallback': function () {
-                        document.location = url;
-                    }
-                });
+                var hitCallback = function(){document.location = url;};
+                if(ga && ga.loaded){
+                    e.preventDefault();
+                    ga('send', 'event', 'outbound', 'click', url, {
+                        'transport': 'beacon',
+                        'hitCallback': hitCallback
+                    });
+                }
             });
         });
     }


### PR DESCRIPTION
This should fixes #12.

Actually that issue mentioned that only "left click" doesn't work, which is because the current code doesn't track when you Ctrl click the link. Also this implementation doesn't respect new window settings of the HTML (e.g. `target="_blank"`). However, I am not planning to improve this in this patch.